### PR TITLE
FIX: Vercel 404 on refresh

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,8 +8,8 @@ export function useAuth() {
 
   useEffect(() => {
     const getSession = async () => {
-      const { data } = await supabase.auth.getSession();
-      setUser(data?.session?.user ?? null);
+      const { data } = await supabase.auth.getUser();
+      setUser(data?.user ?? null);
       setLoading(false);
     };
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,8 +8,8 @@ export function useAuth() {
 
   useEffect(() => {
     const getSession = async () => {
-      const { data } = await supabase.auth.getUser();
-      setUser(data?.user ?? null);
+      const { data } = await supabase.auth.getSession();
+      setUser(data?.session?.user ?? null);
       setLoading(false);
     };
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
**BUG**: After a user is authenticated, any refresh results in a Vercel 404 response.

**Problem**: When we refresh on a url like `/dashboard/list/684f0097-46e8-40fa-99dc-57da0ed743b2` vercel looks for a physical file at that path, but since the app is using client side routing (react-router) this route doesn't exist.

**Solution**: I need to configure Vercel to serve the index.html file for all routes that don't match static assets.

```json
{
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "/index.html"
    }
  ]
}
```
This tells Vercel to serve the index.html file for all requests, allowing React Router to handle the routing client-side.